### PR TITLE
Fixed task size input.

### DIFF
--- a/client/styles/app.scss
+++ b/client/styles/app.scss
@@ -78,3 +78,15 @@ td {
         margin-right: 1em;
     }
 }
+
+.kb-field-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    .kb-flex-grow {
+        flex-grow: 1;
+    }
+    > * {
+        margin-right: 2em;
+    }
+}

--- a/client/ui/dialog.jsx
+++ b/client/ui/dialog.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Dialog, Input} from 'react-toolbox';
+import {Dialog, Input, Dropdown} from 'react-toolbox';
 import RichTextEditor from 'react-rte';
 
 class Dialog_ extends React.Component {
@@ -83,6 +83,21 @@ class Editor extends React.Component {
   }
 }
 
+class Select extends React.Component {
+
+  render() {
+    const source = this.props.source.map(
+      (s) => (typeof s === 'object' ? s : {label: s, value: s})
+    );
+    
+    return (
+      <Dropdown {...this.props}
+                source={source} value={this.props.onChange()}
+         />
+    );
+  }
+}
+
 const validate_required =
         (v, name) => v ? null : "Please provide a value for " + name + ".";
 
@@ -148,8 +163,9 @@ class DialogBase extends React.Component {
 
 module.exports = {
   Dialog: Dialog_,
-  Input: Input_,
   Editor: Editor,
+  Input: Input_,
   DialogBase: DialogBase,
+  Select: Select,
   show_dialog: (dialog, state) => () => dialog.show(state)
 };

--- a/client/ui/tasks.jsx
+++ b/client/ui/tasks.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {Card, CardText, Dropdown} from 'react-toolbox';
+import {Card, CardText} from 'react-toolbox';
 import classes from 'classnames';
 import RichTextEditor from 'react-rte';
 
-import {Dialog, DialogBase, Editor, Input} from './dialog';
+import {Dialog, DialogBase, Editor, Input, Select} from './dialog';
 import {Draggable, DropZone} from './dnd';
 import {UserAvatar, UserSelect} from './who';
 
@@ -19,12 +19,14 @@ class TaskDialog extends DialogBase {
         >
         <Input label='Title' required={true} onChange={this.required("title")}
                />
-        <Input label='Size' type="number" required={true}
-               onChange={this.val("size", 1)} />
-        <UserSelect label="Assigned" onChange={this.val("assigned")}
-                    users={this.props.board.users} />
-        <Input
-           label='Blocked' multiline={true} onChange={this.val("blocked")} />
+        <div className="kb-field-row">
+          <Select label='Size' source={[1, 2, 3, 5, 8, 13]}
+                  onChange={this.val("size", 1)} />
+          <UserSelect label="Assigned" onChange={this.val("assigned")}
+                      users={this.props.board.users} />
+          <Input label='Blocked' multiline={true} className="kb-flex-grow"
+                 onChange={this.val("blocked")} />
+        </div>
         <Editor onChange={this.val("description")} />
       </Dialog>
     );


### PR DESCRIPTION
The input type=number was problematic in a number of ways.

I created a simple Select component and changed size to be a select of
1, 3, 5, 8 and 13.  In addition to saner input, this is saner
semantically. (Tasks bigger than 13 points need to be broken apart. :) .)

I also combined the size, assigned and blocked input into a single row
(where there's room) to make the task dialog more compact.